### PR TITLE
Make cron really optional

### DIFF
--- a/Classes/Cron/SyncLdapDataCron.php
+++ b/Classes/Cron/SyncLdapDataCron.php
@@ -13,63 +13,58 @@ use con4gis\LdapBundle\Classes\LdapConnection;
 
 class SyncLdapDataCron
 {
-    public function onMinutely() {
+    public function onMinutely()
+    {
         $db = Database::getInstance();
-        $em = System::getContainer()->get('doctrine.orm.default_entity_manager');
-
-
-
-
-
-        $ldapConnection = new LdapConnection();
-
-        $ldap = $ldapConnection->ldapConnect();
-        $bind = $ldapConnection->ldapBind($ldap);
-
-        $ldapSettingsRepo = $em->getRepository(Con4gisLdapSettings::class);
-        $ldapSettings = $ldapSettingsRepo->findAll();
-
-        $baseDn = $ldapSettings[0]->getBaseDn();
-        $bindDn = $ldapSettings[0]->getBindDn();
-        $bindPassword = $ldapSettings[0]->getPassword();
-        $encryption = $ldapSettings[0]->getEncryption();
-        $server = $ldapSettings[0]->getServer();
-        $port = $ldapSettings[0]->getPort();
-        $updateFilter = "(|(cn=*)(uid=*))";
-        $ldapUsernames = [];
-        if ($server && $port && $encryption) {
-            if ($encryption == 'ssl') {
-                $adServer = 'ldaps://' . $server . ':' . $port;
-            } elseif ($encryption == 'plain' || $encryption == 'tls') {
-                $adServer = 'ldap://' . $server . ':' . $port;
-            }
-        }
-        if ($adServer) {
-            $ldapUsers = $ldapConnection->filterLdap($bindDn, $bindPassword, $updateFilter, $baseDn, $adServer);
-            array_shift($ldapUsers);
-            $ldapUsernameField = strtolower($ldapSettings[0]->getUserFilter());
-            $ldapEmailField = strtolower($ldapSettings[0]->getEmail());
-            $ldapFirstnameField = strtolower($ldapSettings[0]->getFirstname());
-            $ldapLastnameField = strtolower($ldapSettings[0]->getLastname());
-
-            foreach ($ldapUsers as $ldapUser) {
-                $ldapFrontendGroupsRepo = $em->getRepository(Con4gisLdapFrontendGroups::class);
-                $ldapFrontendGroups = $ldapFrontendGroupsRepo->findAll();
-                $mappingDatas = $ldapFrontendGroups[0]->getFieldMapping();
-                $username = $ldapUser[$ldapUsernameField][0];
-                if ($username) {
-                    $ldapUsernames[] = $username;
-                }
-            }
-        }
-
-
-
-
-
         $ldapSettings = $db->prepare("SELECT * FROM tl_c4g_ldap_settings")->execute()->fetchAssoc();
 
         if ($ldapSettings['updateData'] == 1) {
+            $em = System::getContainer()->get('doctrine.orm.default_entity_manager');
+
+
+            $ldapConnection = new LdapConnection();
+
+            $ldap = $ldapConnection->ldapConnect();
+            $bind = $ldapConnection->ldapBind($ldap);
+
+            $ldapSettingsRepo = $em->getRepository(Con4gisLdapSettings::class);
+            $ldapSettings = $ldapSettingsRepo->findAll();
+
+            $baseDn = $ldapSettings[0]->getBaseDn();
+            $bindDn = $ldapSettings[0]->getBindDn();
+            $bindPassword = $ldapSettings[0]->getPassword();
+            $encryption = $ldapSettings[0]->getEncryption();
+            $server = $ldapSettings[0]->getServer();
+            $port = $ldapSettings[0]->getPort();
+            $updateFilter = "(|(cn=*)(uid=*))";
+            $ldapUsernames = [];
+            if ($server && $port && $encryption) {
+                if ($encryption == 'ssl') {
+                    $adServer = 'ldaps://' . $server . ':' . $port;
+                } elseif ($encryption == 'plain' || $encryption == 'tls') {
+                    $adServer = 'ldap://' . $server . ':' . $port;
+                }
+            }
+            if ($adServer) {
+                $ldapUsers = $ldapConnection->filterLdap($bindDn, $bindPassword, $updateFilter, $baseDn, $adServer);
+                array_shift($ldapUsers);
+                $ldapUsernameField = strtolower($ldapSettings[0]->getUserFilter());
+                $ldapEmailField = strtolower($ldapSettings[0]->getEmail());
+                $ldapFirstnameField = strtolower($ldapSettings[0]->getFirstname());
+                $ldapLastnameField = strtolower($ldapSettings[0]->getLastname());
+
+                foreach ($ldapUsers as $ldapUser) {
+                    $ldapFrontendGroupsRepo = $em->getRepository(Con4gisLdapFrontendGroups::class);
+                    $ldapFrontendGroups = $ldapFrontendGroupsRepo->findAll();
+                    $mappingDatas = $ldapFrontendGroups[0]->getFieldMapping();
+                    $username = $ldapUser[$ldapUsernameField][0];
+                    if ($username) {
+                        $ldapUsernames[] = $username;
+                    }
+                }
+            }
+
+
             $ldapConnection = new LdapConnection();
 
             $ldap = $ldapConnection->ldapConnect();

--- a/Classes/Cron/SyncLdapDataCron.php
+++ b/Classes/Cron/SyncLdapDataCron.php
@@ -13,8 +13,7 @@ use con4gis\LdapBundle\Classes\LdapConnection;
 
 class SyncLdapDataCron
 {
-    public function onMinutely()
-    {
+    public function onMinutely() {
         $db = Database::getInstance();
         $ldapSettings = $db->prepare("SELECT * FROM tl_c4g_ldap_settings")->execute()->fetchAssoc();
 
@@ -63,7 +62,6 @@ class SyncLdapDataCron
                     }
                 }
             }
-
 
             $ldapConnection = new LdapConnection();
 
@@ -160,14 +158,6 @@ class SyncLdapDataCron
                 }
             }
 
-        } else {
-            //Delete old con4gis LDAP member
-            $allMember = MemberModel::findBy('con4gisLdapMember', '1');
-            foreach ($allMember as $oneMember) {
-                if (in_array($oneMember->username, $ldapUsernames) && $oneMember->currentLogin == 0) {
-                    $oneMember->delete();
-                }
-            }
         }
     }
 


### PR DESCRIPTION
Currently, if "Automatically update data from LDAP" is inactive, data is updated from LDAP: Users that exist locally as LDAP users but do not exist in LDAP are deleted. 
This is confusing and may lead to errors: in my current setup our LDAP contains >40k users, so fetching all for comparison is not good. This PR changes the behaviour, if "Automatically update data from LDAP" is inactive nothing happens.