### PR TITLE
Make some LDAP user properties readonly

### DIFF
--- a/Classes/LdapCallback.php
+++ b/Classes/LdapCallback.php
@@ -15,16 +15,12 @@ namespace con4gis\LdapBundle\Classes;
 use con4gis\LdapBundle\Resources\contao\models\LdapMemberModel;
 use con4gis\LdapBundle\Resources\contao\models\LdapUserModel;
 use Contao\CoreBundle\DataContainer\PaletteManipulator;
-use Contao\CoreBundle\ServiceAnnotation\Callback;
 use Contao\DataContainer;
 use Contao\Message;
 
 class LdapCallback {
     /**
      * Remove password field, make username and mail read-only if LDAP User/Member
-     *
-     * @Callback(table="tl_user", target="config.onload")
-     * @Callback(table="tl_member", target="config.onload")
      * @param DataContainer $dc
      */
     public function onLoadCallback(DataContainer $dc) : void {
@@ -47,10 +43,10 @@ class LdapCallback {
         }
 
             foreach (['username', 'email'] as $field) {
-                if(!array_key_exists('eval', $GLOBALS['TL_DCA']['tl_user']['fields'][$field]))
-                    $GLOBALS['TL_DCA']['tl_user']['fields'][$field]['eval'] = [];
+                if(!array_key_exists('eval', $GLOBALS['TL_DCA'][$dc->table]['fields'][$field]))
+                    $GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['eval'] = [];
 
-                $GLOBALS['TL_DCA']['tl_user']['fields'][$field]['eval']['readonly'] = true;
+                $GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['eval']['readonly'] = true;
             }
 
             if($dc->table == 'tl_user') {

--- a/Classes/LdapCallback.php
+++ b/Classes/LdapCallback.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * This file is part of con4gis,
+ * the gis-kit for Contao CMS.
+ *
+ * @package     con4gis
+ * @version     7
+ * @author      con4gis contributors (see "authors.txt")
+ * @license     LGPL-3.0-or-later
+ * @copyright   Küstenschmiede GmbH Software & Design
+ * @link        https://www.con4gis.org
+ */
+namespace con4gis\LdapBundle\Classes;
+
+use con4gis\LdapBundle\Resources\contao\models\LdapMemberModel;
+use con4gis\LdapBundle\Resources\contao\models\LdapUserModel;
+use Contao\CoreBundle\DataContainer\PaletteManipulator;
+use Contao\CoreBundle\ServiceAnnotation\Callback;
+use Contao\DataContainer;
+use Contao\Message;
+
+class LdapCallback {
+    /**
+     * Remove password field, make username and mail read-only if LDAP User/Member
+     *
+     * @Callback(table="tl_user", target="config.onload")
+     * @Callback(table="tl_member", target="config.onload")
+     * @param DataContainer $dc
+     */
+    public function onLoadCallback(DataContainer $dc) : void {
+        if($dc->id == null)
+            return;
+
+
+        $currentRecord = null;
+
+        if ($dc->table == 'tl_user') {
+            $currentRecord = LdapUserModel::findById($dc->id);
+            if($currentRecord == null || $currentRecord->con4gisLdapUser == 0)
+                return;
+
+        } elseif ($dc->table == 'tl_member') {
+            $currentRecord = LdapMemberModel::findById($dc->id);
+            if($currentRecord == null || $currentRecord->con4gisLdapMember == 0)
+                return;
+
+        }
+
+            foreach (['username', 'email'] as $field) {
+                if(!array_key_exists('eval', $GLOBALS['TL_DCA']['tl_user']['fields'][$field]))
+                    $GLOBALS['TL_DCA']['tl_user']['fields'][$field]['eval'] = [];
+
+                $GLOBALS['TL_DCA']['tl_user']['fields'][$field]['eval']['readonly'] = true;
+            }
+
+            if($dc->table == 'tl_user') {
+                foreach (['login', 'admin', 'default', 'group', 'extend', 'custom'] as $palette) {
+                    PaletteManipulator::create()
+                        ->removeField('password', 'password_legend')
+                        ->removeField('pwChange')
+                        ->applyToPalette($palette, 'tl_user');
+                }
+            } elseif ($dc->table == 'tl_member') {
+                PaletteManipulator::create()
+                    ->removeField('password')
+                    ->applyToSubpalette('login', 'tl_member');
+            }
+
+            Message::addInfo($GLOBALS['TL_LANG'][$dc->table]['ldap_readonly_info']);
+        }
+}

--- a/Classes/LdapConnection.php
+++ b/Classes/LdapConnection.php
@@ -41,6 +41,10 @@ class LdapConnection
                 $ldapUser = ldap_get_entries($ldap, $result);
 
                 $memberGroups = $ldapUser[0]['memberof'];
+
+                if(empty($memberGroups))
+                    return $groups;
+
                 array_shift($memberGroups);
                 foreach ($memberGroups as $memberGroup) {
                     $group = strstr($memberGroup, ',', true);

--- a/Resources/contao/dca/tl_member.php
+++ b/Resources/contao/dca/tl_member.php
@@ -11,7 +11,8 @@
  * @link        https://www.con4gis.org
  *
  */
-use Contao\Backend;
+
+use con4gis\LdapBundle\Classes\LdapCallback;
 
 Contao\CoreBundle\DataContainer\PaletteManipulator::create()
     ->addField(['c4g_internalUserId'], 'personal_legend', Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_APPEND)
@@ -21,6 +22,12 @@ Contao\CoreBundle\DataContainer\PaletteManipulator::create()
     ->addLegend('c4g_company_data', 'personal_legend', Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_AFTER, true)
     ->addField(['c4g_department', 'c4g_room'], 'c4g_company_data', Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_APPEND)
     ->applyToPalette('default', 'tl_member');
+/**
+ * Register callbacks
+ */
+$GLOBALS['TL_DCA']['tl_member']['config']['onload_callback'][] = [
+    LdapCallback::class, 'onLoadCallback'
+];
 
 /**
  * Add fields

--- a/Resources/contao/dca/tl_user.php
+++ b/Resources/contao/dca/tl_user.php
@@ -11,8 +11,15 @@
  * @link        https://www.con4gis.org
  *
  */
-use Contao\Backend;
 
+use con4gis\LdapBundle\Classes\LdapCallback;
+
+/**
+ * Register callbacks
+ */
+$GLOBALS['TL_DCA']['tl_user']['config']['onload_callback'][] = [
+    LdapCallback::class, 'onLoadCallback'
+];
 /**
  * Add fields
  */

--- a/Resources/contao/languages/de/tl_member.php
+++ b/Resources/contao/languages/de/tl_member.php
@@ -18,3 +18,5 @@ $GLOBALS['TL_LANG']['tl_member']['c4g_company_data'] = "Unternehmensdaten";
 $GLOBALS['TL_LANG']['tl_member']['c4g_internalUserId'] = array('Interne Benutzerkennung', 'Bitte geben Sie hier die interne Benutzerkennung aus dem LDAP an.');
 $GLOBALS['TL_LANG']['tl_member']['c4g_department'] = array('Abteilung', 'Bitte geben Sie hier die Abteilung an.');
 $GLOBALS['TL_LANG']['tl_member']['c4g_room'] = array('Raumnummer', 'Bitte geben Sie hier die Raumnummer an.');
+
+$GLOBALS['TL_LANG']['tl_member']['ldap_readonly_info'] = 'Dieser Nutzer wird über LDAP verwaltet, daher sind einige Eigenschaften schreibgeschützt';

--- a/Resources/contao/languages/de/tl_user.php
+++ b/Resources/contao/languages/de/tl_user.php
@@ -1,0 +1,2 @@
+<?php
+$GLOBALS['TL_LANG']['tl_user']['ldap_readonly_info'] = 'Dieser Nutzer wird über LDAP verwaltet, daher sind einige Eigenschaften schreibgeschützt';

--- a/Resources/contao/languages/en/tl_member.php
+++ b/Resources/contao/languages/en/tl_member.php
@@ -18,3 +18,5 @@ $GLOBALS['TL_LANG']['tl_member']['c4g_company_data'] = "Company details";
 $GLOBALS['TL_LANG']['tl_member']['c4g_internalUserId'] = array('Internal user id', 'Please enter the internal user ID from LDAP here.');
 $GLOBALS['TL_LANG']['tl_member']['c4g_department'] = array('Department', 'Please enter the department here.');
 $GLOBALS['TL_LANG']['tl_member']['c4g_room'] = array('Room no.', 'Please enter the room number here.');
+
+$GLOBALS['TL_LANG']['tl_member']['ldap_readonly_info'] = 'This account is managed via LDAP, some properties are read-only';

--- a/Resources/contao/languages/en/tl_user.php
+++ b/Resources/contao/languages/en/tl_user.php
@@ -1,0 +1,2 @@
+<?php
+$GLOBALS['TL_LANG']['tl_user']['ldap_readonly_info'] = 'This account is managed via LDAP, some properties are read-only';


### PR DESCRIPTION
As some stuff is managed via LDAP it should be readonly in Contaos backend. Furthermore has the bugfix from #6 merged, as I needed it for further development.