### PR TITLE
fix dca data type

### DIFF
--- a/Resources/contao/dca/tl_c4g_ldap_settings.php
+++ b/Resources/contao/dca/tl_c4g_ldap_settings.php
@@ -228,7 +228,7 @@ $GLOBALS['TL_DCA']['tl_c4g_ldap_settings'] = array
             'label'                   => &$GLOBALS['TL_LANG']['tl_c4g_ldap_be_groups']['linkWithUserMail'],
             'exclude'                 => true,
             'filter'                  => false,
-            'inputType'               => 'checkbox',
+            'inputType'               => 'text',
             'default'                 => '',
             'eval'                    => ['submitOnChange' => false, 'tl_class'=>'clr'],
         ),


### PR DESCRIPTION
fix this error when saving settings:

An exception occurred while executing 'UPDATE tl_c4g_ldap_settings SET `linkWithUserMail`='' WHERE id='1'': SQLSTATE[HY000]: General error: 1366 Incorrect integer value: '' for column 'linkWithUserMail' at row 1