### PR TITLE
Fix undefined array key deleteConfirm in DCA-Group-Files

### DIFF
--- a/src/Resources/contao/dca/tl_member_group.php
+++ b/src/Resources/contao/dca/tl_member_group.php
@@ -18,20 +18,11 @@ use Contao\Message;
 use Contao\StringUtil;
 
 /**
- * Edit On Load
- */
-
-
-/**
  * Edit Operations
  */
-$GLOBALS['TL_DCA']['tl_member_group']['list']['operations']['delete'] = array
-(
-    'href'                => 'act=delete',
-    'icon'                => 'delete.svg',
-    'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"',
-    'button_callback'     => array('tl_member_group_con4gis', 'deleteUser')
-);
+$GLOBALS['TL_DCA']['tl_member_group']['list']['operations']['delete']['button_callback'] = [
+    'tl_member_group_con4gis', 'deleteUser'
+];
 
 /**
  * Add fields
@@ -59,7 +50,7 @@ class tl_member_group_con4gis extends Contao\Backend
      *
      * @return string
      */
-    public function deleteUser($row, $href, $label, $title, $icon, $attributes)
+    public function deleteUser($row, $href, $label, $title, $icon, $attributes): string
     {
         if ($row['con4gisLdapMemberGroup'] == "1") {
             return "";

--- a/src/Resources/contao/dca/tl_user_group.php
+++ b/src/Resources/contao/dca/tl_user_group.php
@@ -18,20 +18,11 @@ use Contao\Message;
 use Contao\StringUtil;
 
 /**
- * Edit On Load
- */
-
-
-/**
  * Edit Operations
  */
-$GLOBALS['TL_DCA']['tl_user_group']['list']['operations']['delete'] = array
-(
-    'href'                => 'act=delete',
-    'icon'                => 'delete.svg',
-    'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"',
-    'button_callback'     => array('tl_user_group_con4gis', 'deleteUser')
-);
+$GLOBALS['TL_DCA']['tl_user_group']['list']['operations']['delete']['button_callback'] = [
+    'tl_user_group_con4gis', 'deleteUser'
+];
 
 /**
  * Add fields
@@ -59,7 +50,7 @@ class tl_user_group_con4gis extends Contao\Backend
      *
      * @return string
      */
-    public function deleteUser($row, $href, $label, $title, $icon, $attributes)
+    public function deleteUser($row, $href, $label, $title, $icon, $attributes): string
     {
         if ($row['con4gisLdapUserGroup'] == "1") {
             return "";


### PR DESCRIPTION
Hi,

beim Betrieb eures LDAP-Plugins taucht beim Leeren des Caches immer folgende PHP Warning auf:

PHP Warning:  Undefined array key "deleteConfirm" in /var/www/htdocs/xxx/var/cache/prod/contao/dca/tl_member_group.php on line 56
PHP Warning:  Undefined array key "deleteConfirm" in /var/www/htdocs/xxx/var/cache/prod/contao/dca/tl_user_group.php on line 159

Wir haben uns das angeschaut und die Ursache liegt daran, dass Ihr in eurem Code versucht auf $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] zuzugreifen - dieser Language-Abschnitt ist aber zu dem Zeitpunkt noch nicht verfügbar und wirft daher diese Fehlermeldung aus.

Der original Contao Code (siehe hier: https://github.com/contao/contao/blob/68b169eca43e4fc7ef3dddc7336b0c84905dec92/core-bundle/src/Resources/contao/dca/tl_member_group.php#L75) prüft vorab ob dieser Array-Bereich verfügbar ist.


Da der komplette delete-Block überschrieben wird (dieser aber bis auf die Callback-Action gleich dem originalen Code ist) habe ich alles bis auf die Callback Aktion umgestellt.

Schaut mal ob das für Euche eine Lösung ist.


